### PR TITLE
extra location device attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 doc/*
 .js
+*.js
+*.map

--- a/README.md
+++ b/README.md
@@ -1,2 +1,108 @@
-pimatic-location-plugin
-=======================
+# pimatic-location
+
+To use this app you need to install the Plugin "pimatic-location".
+You need to add a device to your Pimatic config for each smartphone that should report it's location.
+
+Plugin:
+
+Simply add 
+```
+    {
+      "plugin": "location"
+    },
+```
+to your plugin configuration.
+
+For each Device (Smartphone) you want to 'track', you need to create a corresponding device in your config.
+Example:
+```
+    {
+      "id": "your-phone",
+      "name": "your-phone",
+      "class": "LocationDevice",
+      "lat": 52.5200066,
+      "long": 13.404954
+    },
+```
+
+If you want to use the Apple iCloud to locate your Devices your Device-Configuration should look like this:
+```
+    {
+      "id": "your-phone",
+      "name": "your-phone",
+      "class": "LocationDevice",
+      "lat": 52.5200066,
+      "long": 13.404954,
+      "iCloudUser": "Username",
+      "iCloudPass": "Password",
+      "iCloudDevice": "DeviceName",
+      "iCloudInterval": 60000
+    },
+```
+
+Optional parameters for each Device:
+```
+      "useGoogleMaps": true,
+      "googleMapsApiKey": "your-api-key-here"      
+```
+With the optional parameter "useGoogleMaps" you can optionaly disable the usage of GoogleMaps. (You no longer get a route-distance, eta or address)
+With the parameter "googleMapsApiKey" you can define your own ApiKey, if you got to many googleMapsApi-requests running.
+You can obtain a ApiKey in the Google developers console https://console.developers.google.com . You need also to activate the "Directions API" in your account.
+
+The lat and long values correspond to the location you want the distance to be calculated.
+You can use this website to get your longitude and latitude.
+http://www.mapcoordinates.net/en
+
+Use "xAttributeOptions" to manage which attributes of the tracked device will be visible in the web frontend.
+```
+      "xAttributeOptions": [
+        {
+          "name": "updateTimeSpec",
+          "displaySparkline": false,
+          "hidden": true
+        },
+        {
+          "name": "updateTimeStamp",
+          "displaySparkline": false,
+          "hidden": true
+        },
+        {
+          "name": "currentLat",
+          "displaySparkline": false,
+          "hidden": true
+        },
+        {
+          "name": "currentLong",
+          "displaySparkline": false,
+          "hidden": true
+        },
+        {
+          "name": "linearDistance",
+          "displaySparkline": true,
+          "hidden": false
+        },
+        {
+          "name": "routeDistance",
+          "displaySparkline": true,
+          "hidden": false
+        },
+        {
+          "name": "eta",
+          "displaySparkline": false,
+          "hidden": false
+        },
+        {
+          "name": "address",
+          "displaySparkline": false,
+          "hidden": false
+        },
+        {
+          "name": "lastError",
+          "displaySparkline": false,
+          "hidden": true
+        }
+      ]
+
+```
+
+Additional information on how to track Android devices and at https://github.com/Oitzu/pimatic-location.  


### PR DESCRIPTION
Thanks for the great plugin and the Android client!

I've just added a few additional attributes to the location device object. The attributes are hidden by default and can be displayed in the frontend with xAttributeOptions. They can also be easily used by rules, other plugins and through the Pimatic API by any remote client.

New attributes are:

- **updateTimeStamp**: UNIX UTC timestamp of last update (seconds)
- **updateTimeSpec**: String representation of the timestamp to be displayed in the frontend
- **currentLat**: current latitude value (degrees) of device
- **currentLong**: current longitude value (degrees) of device
- **lastError**: descriptive error message from the last failed iCloud or Google Maps operation

Furthermore and copied the plugin specific documentation from the parent repository into the README.md of the plugin repo and added some information about the xAttributeOptions usage.
